### PR TITLE
fix: propagate adult content filter to all movie and person endpoints

### DIFF
--- a/api/movieRouter.py
+++ b/api/movieRouter.py
@@ -28,14 +28,15 @@ def get_movie_service() -> IMovieService:
     return MovieService(repository, release_dates_repository, credits_repository, videos_repository, watch_providers_repository)
 
 @movie_router.get("/id/{movie_id}")
-async def get_movie_by_id(movie_id: int, service: IMovieService = Depends(get_movie_service)):
+async def get_movie_by_id(movie_id: int, include_adult: bool = Depends(get_adult_content), service: IMovieService = Depends(get_movie_service)):
     """
-    Returns the details for a movie based on the movie id
-    :param movie_id: the movie id to get
-    :param service: the service to call to get the info
-    :return: the details of the movie / or a 404 error if the id does not exist
-    """
-    movie = service.find_by_id(movie_id)
+        Returns the details for a movie based on the movie id
+        :param include_adult:
+        :param movie_id: the movie id to get
+        :param service: the service to call to get the info
+        :return: the details of the movie / or a 404 error if the id does not exist
+        """
+    movie = service.find_by_id(movie_id, include_adult)
     if movie:
         return movie
     else:
@@ -43,8 +44,8 @@ async def get_movie_by_id(movie_id: int, service: IMovieService = Depends(get_mo
 
 
 @movie_router.get("/search/{search}")
-async def search_movies(search: str, service: IMovieService = Depends(get_movie_service)):
-    movies = service.search(search)
+async def search_movies(search: str, include_adult: bool = Depends(get_adult_content), service: IMovieService = Depends(get_movie_service)):
+    movies = service.search(search, include_adult)
     if movies is not None:
         return movies
     else:
@@ -52,14 +53,16 @@ async def search_movies(search: str, service: IMovieService = Depends(get_movie_
 
 
 @movie_router.get("/popular/{time_window}")
-async def get_movie_by_time_window(time_window: str, page: int = 1, service: IMovieService = Depends(get_movie_service)):
+async def get_movie_by_time_window(time_window: str, page: int = 1, include_adult: bool = Depends(get_adult_content), service: IMovieService = Depends(get_movie_service)):
     """
-    Returns the details for a movie based on the movie id
-    :param movie_id: the movie id to get
-    :param service: the service to call to get the info
-    :return: the details of the movie / or a 404 error if the id does not exist
-    """
-    movies = service.find_by_time_window(time_window, page)
+        Returns the details for a movie based on the movie id
+        :param include_adult:
+        :param page:
+        :param time_window:
+        :param service: the service to call to get the info
+        :return: the details of the movie / or a 404 error if the id does not exist
+        """
+    movies = service.find_by_time_window(time_window, page, include_adult)
     if movies:
         return movies
     else:
@@ -67,8 +70,8 @@ async def get_movie_by_time_window(time_window: str, page: int = 1, service: IMo
 
 
 @movie_router.get("/genres/{genre}")
-async def get_movie_by_genre(genre: str, service: IMovieService = Depends(get_movie_service)):
-    movies = service.find_by_genre(genre)
+async def get_movie_by_genre(genre: str, include_adult: bool = Depends(get_adult_content), service: IMovieService = Depends(get_movie_service)):
+    movies = service.find_by_genre(genre, include_adult)
     if movies:
         return movies
     else:

--- a/api/personRouter.py
+++ b/api/personRouter.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 from fastapi.params import Depends
 from starlette.exceptions import HTTPException
 
+from api.auth.verify_auth_token import get_adult_content
 from domain.interfaces.repositories.i_person_repository import IPersonRepository
 from domain.interfaces.services.i_person_service import IPersonService
 from service.person_service import PersonService
@@ -14,14 +15,15 @@ def get_person_service() -> IPersonService:
     return PersonService(repository)
 
 @person_router.get("/{person_id}")
-async def get_person_by_id(person_id: int, service: IPersonService = Depends(get_person_service)):
+async def get_person_by_id(person_id: int, include_adult: bool = Depends(get_adult_content), service: IPersonService = Depends(get_person_service)):
     """
-    Returns the details for a person based on the person id
-    :param person_id: the person id
-    :param service: the service to call to get the info
-    :return: the details of the person / or a 404 error if the id does not exist
-    """
-    person = service.find_by_id(person_id)
+        Returns the details for a person based on the person id
+        :param include_adult:
+        :param person_id: the person id
+        :param service: the service to call to get the info
+        :return: the details of the person / or a 404 error if the id does not exist
+        """
+    person = service.find_by_id(person_id, include_adult)
     if person:
         return person
     else:

--- a/domain/interfaces/repositories/i_credits_repository.py
+++ b/domain/interfaces/repositories/i_credits_repository.py
@@ -4,5 +4,5 @@ from domain.models.credits import Credits
 
 
 class ICreditsRepository(Protocol):
-    def find_by_id(self, movie_id: int) -> Optional[Credits]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[Credits]:
         ...

--- a/domain/interfaces/repositories/i_movie_repository.py
+++ b/domain/interfaces/repositories/i_movie_repository.py
@@ -8,19 +8,19 @@ from domain.models.movie_list_item import MovieListItem
 
 
 class IMovieRepository(Protocol):
-    def find_by_id(self, movie_id: int) -> Optional[MovieDetail]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[MovieDetail]:
         ...
 
-    def search(self, search_term: str) -> Optional[list[Movie]]:
+    def search(self, search_term: str, include_adult: bool) -> Optional[list[Movie]]:
         ...
 
-    def find_by_time_window(self, time_window: str, page: int) -> Optional[PopularMovieList]:
+    def find_by_time_window(self, time_window: str, page: int, include_adult: bool) -> Optional[PopularMovieList]:
         ...
 
     def movie_runtime(self, movie_ids: List[int]) -> int:
         ...
 
-    def find_by_genre(self, genre: str) -> Optional[PopularMovieList]:
+    def find_by_genre(self, genre: str, include_adult: bool) -> Optional[PopularMovieList]:
         ...
 
     def get_random_movies(self, count: int = 50, include_adult: bool = False) -> Optional[List[MovieListItem]]:

--- a/domain/interfaces/repositories/i_person_repository.py
+++ b/domain/interfaces/repositories/i_person_repository.py
@@ -3,5 +3,5 @@ from typing import Protocol, Optional
 from domain.models.person import PersonDetail
 
 class IPersonRepository(Protocol):
-    def find_by_id(self, actor_id: int) -> Optional[PersonDetail]:
+    def find_by_id(self, actor_id: int, include_adult: bool) -> Optional[PersonDetail]:
         ...

--- a/domain/interfaces/services/i_credits_service.py
+++ b/domain/interfaces/services/i_credits_service.py
@@ -4,5 +4,5 @@ from domain.models.credits import Credits
 
 
 class ICreditsService(Protocol):
-    def find_by_id(self, movie_id: int) -> Optional[Credits]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[Credits]:
         ...

--- a/domain/interfaces/services/i_movie_service.py
+++ b/domain/interfaces/services/i_movie_service.py
@@ -5,16 +5,16 @@ from domain.models.movie_list_item import MovieListItem
 
 
 class IMovieService(Protocol):
-    def find_by_id(self, movie_id: int) -> Optional[MovieDetail]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[MovieDetail]:
         ...
 
-    def search(self, search_term: str) -> Optional[list[Movie]]:
+    def search(self, search_term: str, include_adult: bool) -> Optional[list[Movie]]:
         ...
 
-    def find_by_time_window(self, time_window: str, page: int) -> Optional[PopularMovieList]:
+    def find_by_time_window(self, time_window: str, page: int, include_adult: bool) -> Optional[PopularMovieList]:
         ...
 
-    def find_by_genre(self, genre: str) -> Optional[PopularMovieList]:
+    def find_by_genre(self, genre: str, include_adult: bool) -> Optional[PopularMovieList]:
         ...
         
     def get_random_movies(self, count: int = 50, include_adult: bool = False) -> Optional[List[MovieListItem]]:

--- a/domain/interfaces/services/i_person_service.py
+++ b/domain/interfaces/services/i_person_service.py
@@ -3,5 +3,5 @@ from typing import Protocol, Optional
 from domain.models.person import PersonDetail
 
 class IPersonService(Protocol):
-    def find_by_id(self, movie_id: int) -> Optional[PersonDetail]:
+    def find_by_id(self, person_id: int, include_adult: bool) -> Optional[PersonDetail]:
         ...

--- a/repository/credits_repository.py
+++ b/repository/credits_repository.py
@@ -6,15 +6,15 @@ from domain.interfaces.repositories.i_credits_repository import ICreditsReposito
 
 
 class CreditsRepository(ICreditsRepository):
-    def find_by_id(self, movie_id: int) -> Optional[Credits]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[Credits]:
         endpoint = f"/movie/{movie_id}/credits"
 
         result = call_tmdb_api(endpoint)
 
         credits = Credits(
             id=result["id"],
-            cast=[member for member in result["cast"] if member["adult"] == False],
-            crew=[member for member in result["crew"] if member["adult"] == False],
+            cast=[member for member in result["cast"] if include_adult or not member["adult"]],
+            crew=[member for member in result["crew"] if include_adult or not member["adult"]],
         )
 
         return credits

--- a/repository/movie_repository.py
+++ b/repository/movie_repository.py
@@ -2,7 +2,6 @@ from typing import Optional, List
 
 from domain.interfaces.repositories.i_movie_repository import IMovieRepository
 from domain.models.movie import PopularMovieList, MovieDetail
-from domain.models.movieRecommendation import MovieRecommendation
 from domain.models.movie_list_item import MovieListItem
 from utils.tmdb_service import call_tmdb_api
 from database.db import SessionLocal
@@ -10,10 +9,13 @@ from database.models import Movie as DBMovie
 from sqlalchemy import func
 
 class MovieRepository(IMovieRepository):
-    def find_by_id(self, movie_id: int) -> Optional[MovieDetail]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[MovieDetail]:
         endpoint = f"/movie/{movie_id}?language=fr-FR"
 
         result = call_tmdb_api(endpoint)
+
+        if not include_adult and result.get("adult"):
+            return None
 
         movie = MovieDetail(
             id=result["id"],
@@ -37,8 +39,9 @@ class MovieRepository(IMovieRepository):
         return movie
 
 
-    def search(self, search_term: str) -> Optional[list[MovieDetail]]:
-        endpoint = f"/search/movie?query={search_term}&include_adult=false&language=fr-FR"
+    def search(self, search_term: str, include_adult: bool) -> Optional[list[MovieDetail]]:
+        adult_str = "true" if include_adult else "false"
+        endpoint = f"/search/movie?query={search_term}&include_adult={adult_str}&language=fr-FR"
 
         result = call_tmdb_api(endpoint)
 
@@ -66,22 +69,25 @@ class MovieRepository(IMovieRepository):
 
         return movies
 
-    def find_by_time_window(self, time_window: str, page: int) -> Optional[PopularMovieList]:
+    def find_by_time_window(self, time_window: str, page: int, include_adult: bool) -> Optional[PopularMovieList]:
         endpoint = f"/trending/movie/{time_window}?page={page}&language=fr-FR"
 
         result = call_tmdb_api(endpoint)
 
+        results = result["results"] if include_adult else [r for r in result["results"] if not r.get("adult")]
+
         movies = PopularMovieList(
             page=result["page"],
-            results=result["results"],
+            results=results,
             total_results=result["total_pages"],
             total_pages=result["total_results"]
         )
 
         return movies
 
-    def find_by_genre(self, genre: str) -> Optional[PopularMovieList]:
-        endpoint = f"/discover/movie?with_genres={genre}&include_adult=false&include_video=false&language=fr-FR&page=1&sort_by=popularity.desc"
+    def find_by_genre(self, genre: str, include_adult: bool) -> Optional[PopularMovieList]:
+        adult_str = "true" if include_adult else "false"
+        endpoint = f"/discover/movie?with_genres={genre}&include_adult={adult_str}&include_video=false&language=fr-FR&page=1&sort_by=popularity.desc"
 
         result = call_tmdb_api(endpoint)
 
@@ -103,7 +109,7 @@ class MovieRepository(IMovieRepository):
         except Exception as e:
             print(f"[ERREUR] Exception dans movie_runtime : {e}")
             return 0
-        
+
     def get_random_movies(self, count: int = 50, include_adult: bool = False) -> Optional[List[MovieListItem]]:
 
         movies: List[DBMovie] = []

--- a/repository/person_repository.py
+++ b/repository/person_repository.py
@@ -6,7 +6,7 @@ from utils.tmdb_service import call_tmdb_api
 from domain.models.combined_credits import CombinedCredits
 
 class PersonRepository(IPersonRepository):
-    def find_by_id(self, person_id: int) -> Optional[PersonDetail]:
+    def find_by_id(self, person_id: int, include_adult: bool) -> Optional[PersonDetail]:
         endpoint = f"/person/{person_id}?append_to_response=combined_credits&language=fr-FR"
 
         result = call_tmdb_api(endpoint)
@@ -20,7 +20,6 @@ class PersonRepository(IPersonRepository):
             "place_of_birth": result["place_of_birth"],
             "profile_path": result["profile_path"],
         }
-        
 
         refactored_cast = [
             {
@@ -30,7 +29,7 @@ class PersonRepository(IPersonRepository):
                 "media_type": item.get("media_type"),
                 "popularity": item.get("popularity")
             }
-            for item in result["combined_credits"]["cast"] if item["adult"] == False
+            for item in result["combined_credits"]["cast"] if include_adult or not item["adult"]
         ]
         refactored_cast = sorted(refactored_cast, key=lambda x: x.get("popularity", 0), reverse=True)
 
@@ -42,7 +41,7 @@ class PersonRepository(IPersonRepository):
                 "media_type": item.get("media_type"),
                 "popularity": item.get("popularity")
             }
-            for item in result["combined_credits"]["crew"] if item["adult"] == False
+            for item in result["combined_credits"]["crew"] if include_adult or not item["adult"]
         ]
         refactored_crew = sorted(refactored_crew, key=lambda x: x.get("popularity", 0), reverse=True)
 

--- a/service/movie_service.py
+++ b/service/movie_service.py
@@ -32,11 +32,11 @@ class MovieService(IMovieService):
         self.videos_repository = videos_repository
         self.watch_providers_repository = watch_providers_repository
 
-    def find_by_id(self, movie_id: int) -> Optional[MovieDetail]:
+    def find_by_id(self, movie_id: int, include_adult: bool) -> Optional[MovieDetail]:
         with ThreadPoolExecutor() as executor:
-            f_movie          = executor.submit(self.repository.find_by_id, movie_id)
+            f_movie          = executor.submit(self.repository.find_by_id, movie_id, include_adult)
             f_release_dates  = executor.submit(self.release_dates_repository.find_by_id, movie_id)
-            f_credits        = executor.submit(self.credits_repository.find_by_id, movie_id)
+            f_credits        = executor.submit(self.credits_repository.find_by_id, movie_id, include_adult)
             f_videos         = executor.submit(self.videos_repository.find_by_id, movie_id)
             f_watch_providers = executor.submit(self.watch_providers_repository.find_by_id, movie_id)
             f_deeplinks      = executor.submit(get_streaming_links, movie_id)
@@ -98,14 +98,14 @@ class MovieService(IMovieService):
             "providers_link": providers_link
         }
 
-    def search(self, search_term: str) -> Optional[list[Movie]]:
-        return self.repository.search(search_term)
+    def search(self, search_term: str, include_adult: bool) -> Optional[list[Movie]]:
+        return self.repository.search(search_term, include_adult)
 
-    def find_by_time_window(self, time_window: str, page: int) -> Optional[Movie]:
-        return self.repository.find_by_time_window(time_window, page)
+    def find_by_time_window(self, time_window: str, page: int, include_adult: bool) -> Optional[Movie]:
+        return self.repository.find_by_time_window(time_window, page, include_adult)
 
-    def find_by_genre(self, genre: str) -> Optional[PopularMovieList]:
-        return self.repository.find_by_genre(genre)
+    def find_by_genre(self, genre: str, include_adult: bool) -> Optional[PopularMovieList]:
+        return self.repository.find_by_genre(genre, include_adult)
 
     def get_random_movies(self, count: int = 50, include_adult: bool = False) -> Optional[List[MovieListItem]]:
         movies = self.repository.get_random_movies(count, include_adult)

--- a/service/person_service.py
+++ b/service/person_service.py
@@ -7,8 +7,8 @@ class PersonService(IPersonService):
     def __init__(self, repository: IPersonRepository):
         self.repository = repository
 
-    def find_by_id(self, person_id: int) -> Optional[PersonDetail]:
-        person, combined_credits = self.repository.find_by_id(person_id)
+    def find_by_id(self, person_id: int, include_adult: bool) -> Optional[PersonDetail]:
+        person, combined_credits = self.repository.find_by_id(person_id, include_adult)
 
         return {
             "person": person,

--- a/tests/api/test_movieRouter.py
+++ b/tests/api/test_movieRouter.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from unittest.mock import Mock, patch
 
 from api.movieRouter import movie_router, get_movie_service
+from api.auth.verify_auth_token import get_adult_content
 from domain.models.movie import Movie, MovieDetail, PopularMovieList
 
 
@@ -85,13 +86,7 @@ def test_app(mock_movie_service):
 
     # Injection de dépendances pour utiliser le service simulé
     app.dependency_overrides[get_movie_service] = get_test_movie_service
-
-    # Middleware pour simuler un utilisateur authentifié
-    @app.middleware("http")
-    async def mock_auth_middleware(request, call_next):
-        request.state.user = {"id": "test-user-id"}
-        response = await call_next(request)
-        return response
+    app.dependency_overrides[get_adult_content] = lambda: False
 
     # Inclure le routeur pour les films
     app.include_router(movie_router)
@@ -117,7 +112,7 @@ class TestMovieRouter:
         assert movie_data["title"] == "Test Movie FR"
         assert movie_data["age_restriction"] == "12"
         assert movie_data["video_key"] == "video_key"
-        mock_movie_service.find_by_id.assert_called_once_with(123)
+        mock_movie_service.find_by_id.assert_called_once_with(123, False)
 
     # Test de la route pour récupérer un film par ID qui n'existe pas
     def test_get_movie_by_id_not_found(self, client, mock_movie_service):
@@ -128,7 +123,7 @@ class TestMovieRouter:
         # Vérification que la réponse est une erreur 404
         assert response.status_code == 404
         assert response.json()["detail"] == "Movie not found"
-        mock_movie_service.find_by_id.assert_called_once_with(999)
+        mock_movie_service.find_by_id.assert_called_once_with(999, False)
 
     # Test de la route de recherche de films
     def test_search_movies(self, client, mock_movie_service):
@@ -140,7 +135,7 @@ class TestMovieRouter:
         assert len(movies) == 1
         assert movies[0]["id"] == 123
         assert movies[0]["title"] == "Test Movie FR"
-        mock_movie_service.search.assert_called_once_with("Test Movie")
+        mock_movie_service.search.assert_called_once_with("Test Movie", False)
 
     # Test de la recherche de films qui ne trouve rien
     def test_search_movies_not_found(self, client, mock_movie_service):
@@ -151,7 +146,7 @@ class TestMovieRouter:
         # Vérification que la recherche retourne une erreur 404
         assert response.status_code == 404
         assert response.json()["detail"] == "Movies not found"
-        mock_movie_service.search.assert_called_once_with("NonExistentMovie")
+        mock_movie_service.search.assert_called_once_with("NonExistentMovie", False)
 
     # Test de la route pour récupérer les films populaires selon une période
     def test_get_movie_by_time_window(self, client, mock_movie_service):
@@ -163,7 +158,7 @@ class TestMovieRouter:
         assert data["page"] == 1
         assert len(data["results"]) == 1
         assert data["results"][0]["id"] == 123
-        mock_movie_service.find_by_time_window.assert_called_once_with("week", 1)
+        mock_movie_service.find_by_time_window.assert_called_once_with("week", 1, False)
 
     # Test de la récupération de films populaires selon une période avec un résultat vide
     def test_get_movie_by_time_window_not_found(self, client, mock_movie_service):
@@ -174,4 +169,4 @@ class TestMovieRouter:
         # Vérification que la réponse est une erreur 404
         assert response.status_code == 404
         assert response.json()["detail"] == "Movies not found"
-        mock_movie_service.find_by_time_window.assert_called_once_with("decade", 1)
+        mock_movie_service.find_by_time_window.assert_called_once_with("decade", 1, False)

--- a/tests/repository/test_movie_repository.py
+++ b/tests/repository/test_movie_repository.py
@@ -32,7 +32,7 @@ class TestMovieRepository:
         repository = MovieRepository()
 
         # Appel de la méthode find_by_id avec un ID de film
-        result = repository.find_by_id(123)
+        result = repository.find_by_id(123, False)
 
         # Vérification que le résultat est bien une instance de MovieDetail
         assert isinstance(result, MovieDetail)
@@ -70,7 +70,7 @@ class TestMovieRepository:
         repository = MovieRepository()
 
         # Appel de la méthode search pour rechercher un film
-        result = repository.search("test movie")
+        result = repository.search("test movie", False)
 
         # Vérification que le nombre de résultats est correct
         assert len(result) == 1
@@ -102,7 +102,7 @@ class TestMovieRepository:
         repository = MovieRepository()
 
         # Appel de la méthode find_by_time_window pour récupérer les films populaires
-        result = repository.find_by_time_window("week", 1)
+        result = repository.find_by_time_window("week", 1, False)
 
         # Vérification que le résultat est une instance de PopularMovieList
         assert isinstance(result, PopularMovieList)

--- a/tests/service/test_movie_service.py
+++ b/tests/service/test_movie_service.py
@@ -145,7 +145,7 @@ class TestMovieService:
             mock_watch_providers_repository
         )
 
-        result = service.find_by_id(123)
+        result = service.find_by_id(123, False)
 
         # Vérification que les données du film sont correctes
         assert result["id"] == 123
@@ -154,9 +154,9 @@ class TestMovieService:
         assert result["video_key"] == "video_key"
         assert result["director"]["name"] == "Director"
         assert result["composer"]["name"] == "Composer"
-        mock_movie_repository.find_by_id.assert_called_once_with(123)
+        mock_movie_repository.find_by_id.assert_called_once_with(123, False)
         mock_release_dates_repository.find_by_id.assert_called_once_with(123)
-        mock_credits_repository.find_by_id.assert_called_once_with(123)
+        mock_credits_repository.find_by_id.assert_called_once_with(123, False)
         mock_videos_repository.find_by_id.assert_called_once_with(123)
         mock_watch_providers_repository.find_by_id.assert_called_once_with(123)
 
@@ -173,13 +173,13 @@ class TestMovieService:
             mock_watch_providers_repository
         )
 
-        result = service.search("Test Movie")
+        result = service.search("Test Movie", False)
 
         # Vérification que la recherche a retourné un film
         assert len(result) == 1
         assert result[0].id == 123
         assert result[0].title == "Test Movie FR"
-        mock_movie_repository.search.assert_called_once_with("Test Movie")
+        mock_movie_repository.search.assert_called_once_with("Test Movie", False)
 
     # Test de la méthode 'find_by_time_window' pour récupérer les films populaires
     def test_find_by_time_window(self, mock_movie_repository, mock_release_dates_repository,
@@ -193,10 +193,10 @@ class TestMovieService:
             mock_watch_providers_repository
         )
 
-        result = service.find_by_time_window("week", 1)
+        result = service.find_by_time_window("week", 1, False)
 
         # Vérification des films populaires retournés
         assert result.page == 1
         assert len(result.results) == 1
         assert result.results[0]["id"] == 123
-        mock_movie_repository.find_by_time_window.assert_called_once_with("week", 1)
+        mock_movie_repository.find_by_time_window.assert_called_once_with("week", 1, False)


### PR DESCRIPTION
Le filtre contenu adulte n'était appliqué que sur /movies/random, la recherche TMDB (SearchRouter) et les recommandations. Les endpoints suivants ignoraient le setting utilisateur :                        
   
  Corrigé :                                                                                                                                                                                                    
  - GET /movies/id/{id} — bloque les films adultes si le setting est désactivé (retourne 404)
  - GET /movies/search/{search} — passait include_adult=false en dur                                                                                                                                           
  - GET /movies/popular/{time_window} — aucun filtre, post-filtre ajouté sur les résultats TMDB
  - GET /movies/genres/{genre} — passait include_adult=false en dur                                                                                                                                            
  - GET /person/{id} — la filmographie (cast + crew) filtrait toujours les films adultes même avec le setting activé                                                                                           
  - Crédits d'un film — même problème sur le casting                                                                                                                                                           
                                                                                                                                                                                                               
  Changements : include_adult: bool propagé sur toute la chaîne Router → Service → Repository + interfaces mises à jour.